### PR TITLE
cancel now return immediately, and result is consistent.

### DIFF
--- a/async_task.go
+++ b/async_task.go
@@ -38,6 +38,9 @@ var ErrPanic = errors.New("panic")
 // ErrTimeout is returned if task didn't finish within specified time duration.
 var ErrTimeout = errors.New("timeout")
 
+// ErrCanceled is returned if a cancel is triggered
+var ErrCanceled = errors.New("canceled")
+
 // TaskStatus is a handle to the running function.
 // which you can use to wait, cancel, get the result.
 type TaskStatus struct {
@@ -59,7 +62,7 @@ func (t *TaskStatus) State() State {
 func (t *TaskStatus) Cancel() {
 	t.cancelFunc()
 
-	t.state = StateCanceled
+	t.finish(StateCanceled, nil, ErrCanceled)
 }
 
 // Wait block current thread/routine until task finished or failed.
@@ -89,8 +92,8 @@ func (t *TaskStatus) WaitWithTimeout(timeout time.Duration) (interface{}, error)
 	case _ = <-ch:
 		return t.result, t.err
 	case <-time.After(timeout):
-		t.state = StateCanceled
-		return nil, ErrTimeout
+		t.finish(StateCanceled, nil, ErrTimeout)
+		return t.result, t.err
 	}
 }
 

--- a/async_task_test.go
+++ b/async_task_test.go
@@ -65,7 +65,7 @@ func TestCancelFunc(t *testing.T) {
 	t1.Cancel()
 
 	rawResult, err := t1.Wait()
-	assert.NoError(t, err)
+	assert.Equal(t, asynctask.ErrCanceled, err, "should return reason of error")
 
 	assert.Equal(t, asynctask.StateCanceled, t1.State(), "Task should remain in cancel state")
 	assert.Nil(t, rawResult)
@@ -102,6 +102,7 @@ func TestConsistentResultAfterCancel(t *testing.T) {
 
 	// t1 should remain canceled and
 	rawResult, err = t1.Wait()
+	assert.Equal(t, asynctask.ErrCanceled, err, "should return reason of error")
 	assert.Equal(t, asynctask.StateCanceled, t1.State(), "Task should remain in cancel state")
 	assert.Nil(t, rawResult)
 }

--- a/async_task_test.go
+++ b/async_task_test.go
@@ -83,40 +83,79 @@ func TestConsistentResultAfterCancel(t *testing.T) {
 	t.Parallel()
 	ctx := newTestContext(t)
 	t1 := asynctask.Start(ctx, getCountingTask(200*time.Millisecond))
+	t2 := asynctask.Start(ctx, getCountingTask(200*time.Millisecond))
 
 	assert.Equal(t, asynctask.StateRunning, t1.State(), "Task should queued to Running")
 
 	time.Sleep(time.Second * 1)
+	start := time.Now()
 	t1.Cancel()
+	duration := time.Since(start)
+	assert.Equal(t, asynctask.StateCanceled, t1.State(), "t1 should turn to Canceled")
+	assert.True(t, duration < 1*time.Millisecond, "cancel shouldn't take that long")
 
 	// wait til routine finish
-	time.Sleep(time.Second * 1)
-	rawResult, err := t1.Wait()
+	rawResult, err := t2.Wait()
 	assert.NoError(t, err)
+	assert.Equal(t, asynctask.StateCompleted, t2.State(), "t2 should complete")
+	assert.Equal(t, rawResult, 9)
 
+	// t1 should remain canceled and
+	rawResult, err = t1.Wait()
 	assert.Equal(t, asynctask.StateCanceled, t1.State(), "Task should remain in cancel state")
 	assert.Nil(t, rawResult)
+}
+
+func TestConsistentResultAfterTimeout(t *testing.T) {
+	t.Parallel()
+	ctx := newTestContext(t)
+	// t1 wait with short time, expect a timeout
+	t1 := asynctask.Start(ctx, getCountingTask(200*time.Millisecond))
+	// t2 wait with enough time, expect to complete
+	t2 := asynctask.Start(ctx, getCountingTask(200*time.Millisecond))
+
+	assert.Equal(t, asynctask.StateRunning, t1.State(), "t1 should queued to Running")
+	assert.Equal(t, asynctask.StateRunning, t2.State(), "t2 should queued to Running")
+
+	rawResult, err := t1.WaitWithTimeout(1 * time.Second)
+	assert.Equal(t, asynctask.ErrTimeout, err, "should return reason of error")
+	assert.Equal(t, asynctask.StateCanceled, t1.State(), "t1 get canceled after timeout")
+	assert.Nil(t, rawResult, "didn't expect resule on canceled task")
+
+	rawResult, err = t2.WaitWithTimeout(2100 * time.Millisecond)
+	assert.NoError(t, err)
+	assert.Equal(t, asynctask.StateCompleted, t2.State(), "t2 should complete")
+	assert.Equal(t, rawResult, 9)
+
+	// even the t1 go routine finished, it shouldn't change any state
+	assert.Equal(t, asynctask.StateCanceled, t1.State(), "t1 should remain canceled even after routine finish")
+	rawResult, err = t1.Wait()
+	assert.Equal(t, asynctask.ErrTimeout, err, "should return reason of error")
+	assert.Nil(t, rawResult, "didn't expect resule on canceled task")
 }
 
 func TestCrazyCase(t *testing.T) {
 	t.Parallel()
 	ctx := newTestContext(t)
+	numOfTasks := 10000
 	tasks := map[int]*asynctask.TaskStatus{}
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < numOfTasks; i++ {
 		tasks[i] = asynctask.Start(ctx, getCountingTask(200*time.Millisecond))
 	}
 
-	time.Sleep(time.Second * 1)
-	for i := 0; i < 10000; i += 2 {
+	time.Sleep(200 * time.Millisecond)
+	for i := 0; i < numOfTasks; i += 2 {
 		tasks[i].Cancel()
 	}
 
-	for i := 0; i < 10000; i += 1 {
+	for i := 0; i < numOfTasks; i += 1 {
 		rawResult, err := tasks[i].Wait()
-		assert.NoError(t, err)
+
 		if i%2 == 0 {
+			assert.Equal(t, asynctask.ErrCanceled, err, "should be canceled")
 			assert.Nil(t, rawResult)
 		} else {
+			assert.NoError(t, err)
 			assert.NotNil(t, rawResult)
 
 			result := rawResult.(int)


### PR DESCRIPTION
taskState will never change once it reached to a terminal state.