### PR TITLE
differentiate context for start and wait

### DIFF
--- a/async_task.go
+++ b/async_task.go
@@ -39,9 +39,6 @@ var ErrPanic = errors.New("panic")
 // ErrTimeout is returned if task didn't finish within specified time duration.
 var ErrTimeout = errors.New("timeout")
 
-// ErrWaitTimeout is returned on Wait or WaitWithTimeout.
-var ErrWaitTimeout = errors.New("wait timeout")
-
 // ErrCanceled is returned if a cancel is triggered
 var ErrCanceled = errors.New("canceled")
 
@@ -90,7 +87,7 @@ func (t *TaskStatus) Wait(ctx context.Context) (interface{}, error) {
 	case <-ch:
 		return t.result, t.err
 	case <-ctx.Done():
-		return nil, ErrWaitTimeout
+		return nil, ctx.Err()
 	}
 }
 

--- a/async_task.go
+++ b/async_task.go
@@ -36,9 +36,6 @@ type AsyncFunc func(context.Context) (interface{}, error)
 // ErrPanic is returned if panic cought in the task
 var ErrPanic = errors.New("panic")
 
-// ErrTimeout is returned if task didn't finish within specified time duration.
-var ErrTimeout = errors.New("timeout")
-
 // ErrCanceled is returned if a cancel is triggered
 var ErrCanceled = errors.New("canceled")
 

--- a/async_task.go
+++ b/async_task.go
@@ -72,9 +72,8 @@ func (t *TaskStatus) Cancel() {
 }
 
 // Wait block current thread/routine until task finished or failed.
-// !!! we have first context to start asyncTask, second context to wait asyncTask.
-// first context done will timeout and possible stop the asyncTask.
-// second context done will only timeout the Wait, it won't timeout or stop the running task.
+// context passed in can terminate the wait, through context cancellation
+// but won't terminate the task (unless it's same context)
 func (t *TaskStatus) Wait(ctx context.Context) (interface{}, error) {
 	// return immediately if task already in terminal state.
 	if t.state.IsTerminalState() {
@@ -96,6 +95,7 @@ func (t *TaskStatus) Wait(ctx context.Context) (interface{}, error) {
 }
 
 // WaitWithTimeout block current thread/routine until task finished or failed, or exceed the duration specified.
+// timeout only stop waiting, taks will remain running.
 func (t *TaskStatus) WaitWithTimeout(ctx context.Context, timeout time.Duration) (interface{}, error) {
 	// return immediately if task already in terminal state.
 	if t.state.IsTerminalState() {
@@ -121,6 +121,7 @@ func NewCompletedTask() *TaskStatus {
 }
 
 // Start run a async function and returns you a handle which you can Wait or Cancel.
+// context passed in may impact task lifetime (from context cancellation)
 func Start(ctx context.Context, task AsyncFunc) *TaskStatus {
 	ctx, cancel := context.WithCancel(ctx)
 	wg := &sync.WaitGroup{}

--- a/async_task_test.go
+++ b/async_task_test.go
@@ -124,43 +124,6 @@ func TestConsistentResultAfterCancel(t *testing.T) {
 	assert.Nil(t, rawResult)
 }
 
-func TestConsistentResultAfterTimeout(t *testing.T) {
-	t.Parallel()
-	ctx := newTestContext(t)
-	// t1 wait with short time, expect a timeout
-	t1 := asynctask.Start(ctx, getCountingTask(200*time.Millisecond))
-	// t2 wait with enough time, expect to complete
-	t2 := asynctask.Start(ctx, getCountingTask(200*time.Millisecond))
-
-	assert.Equal(t, asynctask.StateRunning, t1.State(), "t1 should queued to Running")
-	assert.Equal(t, asynctask.StateRunning, t2.State(), "t2 should queued to Running")
-
-	rawResult, err := t1.WaitWithTimeout(ctx, 1*time.Second)
-	assert.Equal(t, asynctask.ErrTimeout, err, "should return reason of error")
-	assert.Equal(t, asynctask.StateCanceled, t1.State(), "t1 get canceled after timeout")
-	assert.Nil(t, rawResult, "didn't expect resule on canceled task")
-
-	rawResult, err = t2.WaitWithTimeout(ctx, 2100*time.Millisecond)
-	assert.NoError(t, err)
-	assert.Equal(t, asynctask.StateCompleted, t2.State(), "t2 should complete")
-	assert.Equal(t, rawResult, 9)
-
-	// even the t1 go routine finished, it shouldn't change any state
-	assert.Equal(t, asynctask.StateCanceled, t1.State(), "t1 should remain canceled even after routine finish")
-	rawResult, err = t1.Wait(ctx)
-	assert.Equal(t, asynctask.ErrTimeout, err, "should return reason of error")
-	assert.Nil(t, rawResult, "didn't expect resule on canceled task")
-
-	// invoke WaitWithTimeout again,
-	start := time.Now()
-	rawResult, err = t1.WaitWithTimeout(ctx, 1*time.Second)
-	elapsed := time.Since(start)
-	assert.Equal(t, asynctask.StateCanceled, t1.State(), "t1 should remain canceled even after routine finish")
-	assert.Equal(t, asynctask.ErrTimeout, err, "should return reason of error")
-	assert.Nil(t, rawResult, "didn't expect resule on canceled task")
-	assert.True(t, elapsed.Microseconds() < 2, "Second wait should return immediately")
-}
-
 func TestCompletedTask(t *testing.T) {
 	t.Parallel()
 

--- a/error_test.go
+++ b/error_test.go
@@ -70,7 +70,6 @@ func TestErrorCase(t *testing.T) {
 	_, err := tsk.WaitWithTimeout(ctx, 300*time.Millisecond)
 	assert.Error(t, err)
 	assert.False(t, errors.Is(err, asynctask.ErrPanic), "not expecting ErrPanic")
-	assert.False(t, errors.Is(err, asynctask.ErrTimeout), "not expecting ErrTimeout")
 	assert.False(t, errors.Is(err, context.DeadlineExceeded), "not expecting DeadlineExceeded")
 	assert.Equal(t, "not found", err.Error())
 }

--- a/error_test.go
+++ b/error_test.go
@@ -41,7 +41,7 @@ func TestTimeoutCase(t *testing.T) {
 	ctx := newTestContext(t)
 	tsk := asynctask.Start(ctx, getCountingTask(200*time.Millisecond))
 	_, err := tsk.WaitWithTimeout(ctx, 300*time.Millisecond)
-	assert.True(t, errors.Is(err, asynctask.ErrWaitTimeout), "expecting ErrWaitTimeout")
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "expecting DeadlineExceeded")
 
 	// the last Wait error should affect running task
 	// I can continue wait with longer time
@@ -71,7 +71,7 @@ func TestErrorCase(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, errors.Is(err, asynctask.ErrPanic), "not expecting ErrPanic")
 	assert.False(t, errors.Is(err, asynctask.ErrTimeout), "not expecting ErrTimeout")
-	assert.False(t, errors.Is(err, asynctask.ErrWaitTimeout), "not expecting ErrWaitTimeout")
+	assert.False(t, errors.Is(err, context.DeadlineExceeded), "not expecting DeadlineExceeded")
 	assert.Equal(t, "not found", err.Error())
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -41,7 +41,13 @@ func TestTimeoutCase(t *testing.T) {
 	ctx := newTestContext(t)
 	tsk := asynctask.Start(ctx, getCountingTask(200*time.Millisecond))
 	_, err := tsk.WaitWithTimeout(ctx, 300*time.Millisecond)
-	assert.True(t, errors.Is(err, asynctask.ErrTimeout), "expecting ErrTimeout")
+	assert.True(t, errors.Is(err, asynctask.ErrWaitTimeout), "expecting ErrWaitTimeout")
+
+	// the last Wait error should affect running task
+	// I can continue wait with longer time
+	rawResult, err := tsk.WaitWithTimeout(ctx, 2*time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, 9, rawResult)
 }
 
 func TestPanicCase(t *testing.T) {
@@ -60,6 +66,8 @@ func TestErrorCase(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, errors.Is(err, asynctask.ErrPanic), "not expecting ErrPanic")
 	assert.False(t, errors.Is(err, asynctask.ErrTimeout), "not expecting ErrTimeout")
+	assert.False(t, errors.Is(err, asynctask.ErrWaitTimeout), "not expecting ErrWaitTimeout")
+	assert.Equal(t, "not found", err.Error())
 }
 
 func TestPointerErrorCase(t *testing.T) {

--- a/error_test.go
+++ b/error_test.go
@@ -48,6 +48,11 @@ func TestTimeoutCase(t *testing.T) {
 	rawResult, err := tsk.WaitWithTimeout(ctx, 2*time.Second)
 	assert.NoError(t, err)
 	assert.Equal(t, 9, rawResult)
+
+	// any following Wait should complete immediately
+	rawResult, err = tsk.WaitWithTimeout(ctx, 2*time.Nanosecond)
+	assert.NoError(t, err)
+	assert.Equal(t, 9, rawResult)
 }
 
 func TestPanicCase(t *testing.T) {


### PR DESCRIPTION
- context that pass to Start() will determin task lifetime
- context that pass to Wait() will not impact task lifetime