### PR TITLE
remove restriction on return pointer value of TypeParameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@
 
 Simple mimik of async/await for those come from C# world, so you don't need to dealing with waitGroup/channel in golang.
 
+also the result is strongTyped with go generics, no type assertion is needed.
+
+few chaining method provided:
+- ContinueWith: send task1's output to task2 as input, return reference to task2.
+- AfterBoth : send output of taskA, taskB to taskC as input, return reference to taskC.
+- WaitAll: all of the task have to finish to end the wait (with an option to fail early if any task failed)
+- WaitAny: any of the task finish would end the wait
+
 ```golang
     // start task
     task := asynctask.Start(ctx, countingTask)

--- a/after_both.go
+++ b/after_both.go
@@ -3,20 +3,21 @@ package asynctask
 import "context"
 
 // AfterBothFunc is a function that has 2 input.
-type AfterBothFunc[T, S, R any] func(context.Context, *T, *S) (*R, error)
+type AfterBothFunc[T, S, R any] func(context.Context, T, S) (R, error)
 
 // AfterBoth runs the function after both 2 input task finished, and will be fed with result from 2 input task.
-//   if one of the input task failed, the AfterBoth task will be failed and returned, even other one are still running.
+//
+//	if one of the input task failed, the AfterBoth task will be failed and returned, even other one are still running.
 func AfterBoth[T, S, R any](ctx context.Context, tskT *Task[T], tskS *Task[S], next AfterBothFunc[T, S, R]) *Task[R] {
-	return Start(ctx, func(fCtx context.Context) (*R, error) {
+	return Start(ctx, func(fCtx context.Context) (R, error) {
 		t, err := tskT.Result(fCtx)
 		if err != nil {
-			return nil, err
+			return *new(R), err
 		}
 
 		s, err := tskS.Result(fCtx)
 		if err != nil {
-			return nil, err
+			return *new(R), err
 		}
 
 		return next(fCtx, t, s)
@@ -24,10 +25,11 @@ func AfterBoth[T, S, R any](ctx context.Context, tskT *Task[T], tskS *Task[S], n
 }
 
 // AfterBothActionToFunc convert a Action to Func (C# term), to satisfy the AfterBothFunc interface.
-//   Action is function that runs without return anything
-//   Func is function that runs and return something
-func AfterBothActionToFunc[T, S any](action func(context.Context, *T, *S) error) func(context.Context, *T, *S) (*interface{}, error) {
-	return func(ctx context.Context, t *T, s *S) (*interface{}, error) {
+//
+//	Action is function that runs without return anything
+//	Func is function that runs and return something
+func AfterBothActionToFunc[T, S any](action func(context.Context, T, S) error) func(context.Context, T, S) (interface{}, error) {
+	return func(ctx context.Context, t T, s S) (interface{}, error) {
 		return nil, action(ctx, t, s)
 	}
 }

--- a/after_both_test.go
+++ b/after_both_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func summarize2CountingTask(ctx context.Context, result1, result2 *int) (*int, error) {
+func summarize2CountingTask(ctx context.Context, result1, result2 int) (int, error) {
 	t := ctx.Value(testContextKey).(*testing.T)
 	t.Logf("result1: %d", result1)
 	t.Logf("result2: %d", result2)
-	sum := *result1 + *result2
+	sum := result1 + result2
 	t.Logf("sum: %d", sum)
-	return &sum, nil
+	return sum, nil
 }
 
 func TestAfterBoth(t *testing.T) {
@@ -28,7 +28,7 @@ func TestAfterBoth(t *testing.T) {
 	sum, err := t3.Result(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, asynctask.StateCompleted, t3.State(), "Task should complete with no error")
-	assert.Equal(t, *sum, 18, "Sum should be 18")
+	assert.Equal(t, sum, 18, "Sum should be 18")
 }
 
 func TestAfterBothFailureCase(t *testing.T) {
@@ -56,11 +56,11 @@ func TestAfterBothActionToFunc(t *testing.T) {
 
 	countingTask1 := asynctask.Start(ctx, getCountingTask(10, "afterboth.P1", 20*time.Millisecond))
 	countingTask2 := asynctask.Start(ctx, getCountingTask(10, "afterboth.P2", 20*time.Millisecond))
-	t2 := asynctask.AfterBoth(ctx, countingTask1, countingTask2, asynctask.AfterBothActionToFunc(func(ctx context.Context, result1, result2 *int) error {
+	t2 := asynctask.AfterBoth(ctx, countingTask1, countingTask2, asynctask.AfterBothActionToFunc(func(ctx context.Context, result1, result2 int) error {
 		t := ctx.Value(testContextKey).(*testing.T)
 		t.Logf("result1: %d", result1)
 		t.Logf("result2: %d", result2)
-		sum := *result1 + *result2
+		sum := result1 + result2
 		t.Logf("sum: %d", sum)
 		return nil
 	}))

--- a/after_both_test.go
+++ b/after_both_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask"
+	"github.com/Azure/go-asynctask/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/after_both_test.go
+++ b/after_both_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask/v2"
+	"github.com/Azure/go-asynctask"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/continue_with.go
+++ b/continue_with.go
@@ -3,23 +3,24 @@ package asynctask
 import "context"
 
 // ContinueFunc is a function that can be connected to previous task with ContinueWith
-type ContinueFunc[T any, S any] func(context.Context, *T) (*S, error)
+type ContinueFunc[T any, S any] func(context.Context, T) (S, error)
 
 func ContinueWith[T any, S any](ctx context.Context, tsk *Task[T], next ContinueFunc[T, S]) *Task[S] {
-	return Start(ctx, func(fCtx context.Context) (*S, error) {
+	return Start(ctx, func(fCtx context.Context) (S, error) {
 		result, err := tsk.Result(fCtx)
 		if err != nil {
-			return nil, err
+			return *new(S), err
 		}
 		return next(fCtx, result)
 	})
 }
 
 // ContinueActionToFunc convert a Action to Func (C# term), to satisfy the AsyncFunc interface.
-//   Action is function that runs without return anything
-//   Func is function that runs and return something
-func ContinueActionToFunc[T any](action func(context.Context, *T) error) func(context.Context, *T) (*interface{}, error) {
-	return func(ctx context.Context, t *T) (*interface{}, error) {
+//
+//	Action is function that runs without return anything
+//	Func is function that runs and return something
+func ContinueActionToFunc[T any](action func(context.Context, T) error) func(context.Context, T) (interface{}, error) {
+	return func(ctx context.Context, t T) (interface{}, error) {
 		return nil, action(ctx, t)
 	}
 }

--- a/continue_with_test.go
+++ b/continue_with_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask"
+	"github.com/Azure/go-asynctask/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/continue_with_test.go
+++ b/continue_with_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask/v2"
+	"github.com/Azure/go-asynctask"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/error_test.go
+++ b/error_test.go
@@ -11,16 +11,16 @@ import (
 )
 
 func getPanicTask(sleepDuration time.Duration) asynctask.AsyncFunc[string] {
-	return func(ctx context.Context) (*string, error) {
+	return func(ctx context.Context) (string, error) {
 		time.Sleep(sleepDuration)
 		panic("yo")
 	}
 }
 
 func getErrorTask(errorString string, sleepDuration time.Duration) asynctask.AsyncFunc[int] {
-	return func(ctx context.Context) (*int, error) {
+	return func(ctx context.Context) (int, error) {
 		time.Sleep(sleepDuration)
-		return nil, errors.New(errorString)
+		return 0, errors.New(errorString)
 	}
 }
 
@@ -37,12 +37,12 @@ func TestTimeoutCase(t *testing.T) {
 	// I can continue wait with longer time
 	rawResult, err := tsk.WaitWithTimeout(ctx, 2*time.Second)
 	assert.NoError(t, err)
-	assert.Equal(t, 9, *rawResult)
+	assert.Equal(t, 9, rawResult)
 
 	// any following Wait should complete immediately
 	rawResult, err = tsk.WaitWithTimeout(ctx, 2*time.Nanosecond)
 	assert.NoError(t, err)
-	assert.Equal(t, 9, *rawResult)
+	assert.Equal(t, 9, rawResult)
 }
 
 func TestPanicCase(t *testing.T) {

--- a/error_test.go
+++ b/error_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask"
+	"github.com/Azure/go-asynctask/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/error_test.go
+++ b/error_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask/v2"
+	"github.com/Azure/go-asynctask"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Azure/go-asynctask/v2
+module github.com/Azure/go-asynctask
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Azure/go-asynctask
+module github.com/Azure/go-asynctask/v2
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/go-asynctask
 
-go 1.19
+go 1.20
 
 require github.com/stretchr/testify v1.8.4
 

--- a/task.go
+++ b/task.go
@@ -14,8 +14,8 @@ type AsyncFunc[T any] func(context.Context) (T, error)
 // ActionToFunc convert a Action to Func (C# term), to satisfy the AsyncFunc interface.
 // -  Action is function that runs without return anything
 // -  Func is function that runs and return something
-func ActionToFunc(action func(context.Context) error) func(context.Context) (*interface{}, error) {
-	return func(ctx context.Context) (*interface{}, error) {
+func ActionToFunc(action func(context.Context) error) func(context.Context) (interface{}, error) {
+	return func(ctx context.Context) (interface{}, error) {
 		return nil, action(ctx)
 	}
 }

--- a/task_test.go
+++ b/task_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask"
+	"github.com/Azure/go-asynctask/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/task_test.go
+++ b/task_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask/v2"
+	"github.com/Azure/go-asynctask"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/wait_all_test.go
+++ b/wait_all_test.go
@@ -186,7 +186,7 @@ func TestWaitAllWithNoTasks(t *testing.T) {
 
 // getUncontrollableTask return a task that is not honor context, it only hornor the remoteControl context.
 func getUncontrollableTask(rcCtx context.Context, t *testing.T) asynctask.AsyncFunc[int] {
-	return func(ctx context.Context) (*int, error) {
+	return func(ctx context.Context) (int, error) {
 		for {
 			select {
 			case <-time.After(1 * time.Millisecond):
@@ -195,7 +195,7 @@ func getUncontrollableTask(rcCtx context.Context, t *testing.T) asynctask.AsyncF
 				}
 			case <-rcCtx.Done():
 				t.Logf("[UncontrollableTask]: cancelled by remote control")
-				return nil, rcCtx.Err()
+				return 0, rcCtx.Err()
 			}
 		}
 	}

--- a/wait_all_test.go
+++ b/wait_all_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask/v2"
+	"github.com/Azure/go-asynctask"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/wait_all_test.go
+++ b/wait_all_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask"
+	"github.com/Azure/go-asynctask/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/wait_any_test.go
+++ b/wait_any_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask"
+	"github.com/Azure/go-asynctask/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/wait_any_test.go
+++ b/wait_any_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-asynctask/v2"
+	"github.com/Azure/go-asynctask"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
also
- bump golang version to 1.20
- use sync.RWMutex to replace sync.Mutex
- minor update to readme

this would be breaking change, will bump minor version.